### PR TITLE
Add support for changing title when ending entry and fix tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,22 @@ Now hit the 'Save' button on top and you're all set up!
 ## Usage
 Invoke the extension with the default keyword `clock`.
 
-Basic command structure is like so: `clock (in <args>|out|status)`.
+Basic command structure is like so: `clock (in[ <title>|out[ <title>]|status)`.
+
+`<title>` can contain tags. For example `clock in #call foo` will create a new time entry with the title `foo` and assign the `call` tag to it. If you need to use `#` in the title you can escape it by `\#`. Tag name is one word which can contain letters, numbers, `-`, and `_`. You can use multiple tags, it doesn't matter where in the title you use them. 
 
 ### Creating new time entries
 Using `clock in` will fetch the title and tags of your most recent time entry and re-use that.
 
 `clock in foo` will create a new time entry with the title `foo`.
 
-💡 You can also use tags for example `clock in #call foo` will create a new time entry with the title `foo` and assign the `call` tag to it. If you need to use `#` in the title you can escape it by `\#`. Tag name is one word which can contain letters, numbers, `-`, and `_`. You can use multiple tags and it doesn't matter where in the title you use them. 
+ 
 
 ### Stopping time entries
-`clock out` will stop any ongoing time trackings. This takes no further arguments.
+`clock out` will stop any ongoing time tracking.
+
+`clock out <title>` will update the title (and tags) before stopping the ongoing time tracking. This is useful because sometimes the title of the entry is only clear at the end of it. 
+
 
 ### Status of current time entry
 `clock status` will show you the title and duration fo your currently running time entry.

--- a/main.py
+++ b/main.py
@@ -80,13 +80,13 @@ class KeywordQueryEventListener(EventListener):
                         'message': description
                     })
                 ))
-        if str(query).split(' ')[0] == 'status':
+        if str(query).split(' ')[0] == 'info':
             items.insert(0, ExtensionResultItem(
                 icon='images/icon.png',
-                name='Status of current tracking',
+                name='Current tracking info',
                 description='Get the name and the duration of the currently running tracking',
                 on_enter=ExtensionCustomAction({
-                    'call': 'status'
+                    'call': 'info'
                 })
             ))
 
@@ -290,7 +290,7 @@ class ItemEventListener(EventListener):
             raise RuntimeError(response.status_code)
 
 
-    def status_of_time_entry(self):
+    def current_time_entry_info(self):
         try:
             time_entry = self.get_running_time_entry()
         except ValueError:
@@ -333,8 +333,8 @@ class ItemEventListener(EventListener):
         elif call == 'end_with_update':
             return self.end_time_entry_with_update(message)
 
-        elif call == 'status':
-            return self.status_of_time_entry()
+        elif call == 'info':
+            return self.current_time_entry_info()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added support for an extended version of the out command:
`clock out Some description with #tag and #tag2` will stop the time entry, and update the description and tags.

Also, fixed a case where sometimes the addition of a tag would fail if there were more than 50 tags created in clockify. Only first 50 tags were taken into account)