### PR TITLE
Project selection via clock [in|out] @project

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,19 @@ Basic command structure is like so: `clock (in[ <title>|out[ <title>]|status)`.
 
 `<title>` can contain tags. For example `clock in #call foo` will create a new time entry with the title `foo` and assign the `call` tag to it. If you need to use `#` in the title you can escape it by `\#`. Tag name is one word which can contain letters, numbers, `-`, and `_`. You can use multiple tags, it doesn't matter where in the title you use them. 
 
-### Creating new time entries
-Using `clock in` will fetch the title and tags of your most recent time entry and re-use that.
+`<title>` can contain a project name. For example `clock in foo @project` will create a new time entry with the title `foo` in the project `project`. If you need to use `@` in the title, you can escape it by `\@`. The project name is case insensitive and does not suppport spaces. The first matching project will be choosen, so letters from the end of the project name can be left out. However, beware of projects starting with the same letters.
 
-`clock in foo` will create a new time entry with the title `foo`.
+### Creating new time entries
+Using `clock in` will fetch the title, tags and project of your most recent time entry and re-use that.
+
+`clock in foo` will create a new time entry with the title `foo` in your default project.
 
  
 
 ### Stopping time entries
 `clock out` will stop any ongoing time tracking.
 
-`clock out <title>` will update the title (and tags) before stopping the ongoing time tracking. This is useful because sometimes the title of the entry is only clear at the end of it. 
+`clock out <title>` will update the title (and project and tags) before stopping the ongoing time tracking. This is useful because sometimes the title of the entry is only clear at the end of it. 
 
 
 ### Status of current time entry

--- a/main.py
+++ b/main.py
@@ -163,7 +163,8 @@ class ItemEventListener(EventListener):
         data = json.loads(response.content.decode('utf-8'))
 
         if response.status_code == 200:
-            return data[0].id if len(data) > 0 else None
+            print(data[0])
+            return data[0]['id'] if len(data) > 0 else None
         else:
             raise RuntimeError(f"Failed to get project id by name '{name}'; Error: {response.status_code}")
 
@@ -171,6 +172,8 @@ class ItemEventListener(EventListener):
         reg_exp = "(?<!\\\)@([\w\-_]+)\s?"
 
         project = re.search(reg_exp, message)
+        if project == None:
+            return message, None
         project = project.group(1)
         message = re.sub(reg_exp, "", message)
 

--- a/main.py
+++ b/main.py
@@ -156,10 +156,8 @@ class ItemEventListener(EventListener):
             raise RuntimeError(f"Failed to create tag '{name}'; Error: {response.status_code}")
 
     def get_project_id_by_name(self, name):
-        payload = {
-            'name': name
-        }
-        response = requests.get(f"{self.__base_workspace_url}/projects", json=payload, headers=self.__headers)
+        
+        response = requests.get(f"{self.__base_workspace_url}/projects?name={name}", headers=self.__headers)
         data = json.loads(response.content.decode('utf-8'))
 
         if response.status_code == 200:

--- a/main.py
+++ b/main.py
@@ -155,11 +155,36 @@ class ItemEventListener(EventListener):
         else:
             raise RuntimeError(f"Failed to create tag '{name}'; Error: {response.status_code}")
 
+    def get_project_id_by_name(self, name):
+        payload = {
+            'name': name
+        }
+        response = requests.get(f"{self.__base_workspace_url}/projects", json=payload, headers=self.__headers)
+        data = json.loads(response.content.decode('utf-8'))
+
+        if response.status_code == 200:
+            return data[0].id if len(data) > 0 else None
+        else:
+            raise RuntimeError(f"Failed to get project id by name '{name}'; Error: {response.status_code}")
+
+    def extract_project(self, message):
+        reg_exp = "(?<!\\\)@([\w\-_]+)\s?"
+
+        project = re.search(reg_exp, message)
+        project = project.group(1)
+        message = re.sub(reg_exp, "", message)
+
+        return message, project
 
     def process_message(self, message):
+        (message, project_name) = self.extract_project(message)
+        if project_name:
+            project_id = self.get_project_id_by_name(project_name)
+
         (message, tags) = self.extract_tags(message)
+
         if (len(tags) == 0):
-            return message, []
+            return message, [], project_id
 
         tag_ids = []
 
@@ -172,7 +197,7 @@ class ItemEventListener(EventListener):
             self.logger.debug(f"Tag {tag_name}({tag['id']}) will be attached to time entry")
             tag_ids.append(tag['id'])
 
-        return message, tag_ids
+        return message, tag_ids, project_id
 
 
     def get_last_time_entry(self):
@@ -195,7 +220,7 @@ class ItemEventListener(EventListener):
 
     def start_time_entry(self, message):
         try:
-            (description, tag_ids) = self.process_message(message)
+            (description, tag_ids, project_id) = self.process_message(message)
         except RuntimeError as e:
             return self.notification_action('Unexpected error', f"{e}", 'error')
 
@@ -203,7 +228,7 @@ class ItemEventListener(EventListener):
             'description': description,
             'tagIds': tag_ids,
             'start': self.get_now(),
-            'projectId': self.__project_id
+            'projectId': project_id if project_id != None else self.__project_id,
         }
 
         self.logger.debug("Starting time entry: %s", payload)
@@ -255,14 +280,14 @@ class ItemEventListener(EventListener):
             return self.notification_action('Unexpected error', f"HTTP {e}", 'error')
 
         try:
-            (description, tag_ids) = self.process_message(message)
+            (description, tag_ids, project_id) = self.process_message(message)
         except RuntimeError as e:
             return self.notification_action('Unexpected error', f"{e}", 'error')
 
         payload = {
             'description': description,
             'tagIds': tag_ids,
-            'projectId': self.__project_id,
+            'projectId': project_id if project_id != None else self.__project_id,
             'start': time_entry['timeInterval']['start'],
             'end': self.get_now(),
         }

--- a/main.py
+++ b/main.py
@@ -181,7 +181,8 @@ class ItemEventListener(EventListener):
 
     def process_message(self, message):
         (message, project_name) = self.extract_project(message)
-        if project_name:
+        project_id = None
+        if project_name != None:
             project_id = self.get_project_id_by_name(project_name)
 
         (message, tags) = self.extract_tags(message)
@@ -249,7 +250,7 @@ class ItemEventListener(EventListener):
             'description': last_time_entry['description'],
             'tagIds': last_time_entry['tagIds'],
             'start': self.get_now(),
-            'projectId': self.__project_id
+            'projectId': last_time_entry['projectId']
         }
         response = requests.post(f"{self.__base_workspace_url}/time-entries", json=payload, headers=self.__headers)
         if response.status_code == 201:

--- a/main.py
+++ b/main.py
@@ -289,7 +289,7 @@ class ItemEventListener(EventListener):
         payload = {
             'description': description,
             'tagIds': tag_ids,
-            'projectId': project_id if project_id != None else self.__project_id,
+            'projectId': project_id if project_id != None else time_entry['projectId'],
             'start': time_entry['timeInterval']['start'],
             'end': self.get_now(),
         }


### PR DESCRIPTION
This PR adds the option to choose which project an entry will be logged to via the prompts. In similar fashion to the tags, the `@` symbol can be used to designate the desired project either when starting or when stopping a time entry. 

With `clock in Description @ProjectA`, the new entry with title 'Description' will be created and assigned to project 'ProjectA'. Due to the nature of the Clockify API, the project will be found by first longest prefix matching and the query can be case-insensitive. It should be noted, that only project names without spaces are allowed. 

Without an `@proj` query, the behavior remains mostly unchanged, i.e. fallback to the default project as defined by the extensions settings. Only the entry resumption now also accesses not only the title of the last entry but also the project of the last entry, if defined. 